### PR TITLE
fix: plugin fials if config not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,7 @@ You can also use link attributes:
 }
 ```
 
-If you omit `message`, it defaults to:
-
-```text
-This is a default notification message.
-```
+The `message` field is required. If you don't provide it, the plugin configuration will fail validation.
 
 ## Security
 

--- a/platzky_msgbar/config.py
+++ b/platzky_msgbar/config.py
@@ -13,8 +13,7 @@ class MsgBarConfig(BaseModel):
     All CSS values are validated to prevent CSS injection attacks.
     """
 
-    message: Optional[str] = Field(
-        default="This is a default notification message.",
+    message: str = Field(
         description="The message to display in the bar (supports Markdown)",
     )
 

--- a/platzky_msgbar/entrypoint.py
+++ b/platzky_msgbar/entrypoint.py
@@ -14,7 +14,7 @@ def process(app: Engine, plugin_config: Dict[str, Any]):
     # Convert markdown to HTML (inline only, no <p> tags)
     # attr_list extension allows syntax like: [link](url){:target="_blank"}
     message_html = markdown.markdown(
-        config.message or "This is a default notification message.",
+        config.message,
         extensions=["extra", "attr_list"],
         output_format="html",
     ).strip()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Message field is now mandatory; plugin configuration will fail validation if not provided.

* **Documentation**
  * Updated to reflect the message field as a required parameter.

* **Tests**
  * Added validation test to verify proper error handling for missing message field.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->